### PR TITLE
New sockets

### DIFF
--- a/RemoteTaskServer/Api/Network/Messages/Message.cs
+++ b/RemoteTaskServer/Api/Network/Messages/Message.cs
@@ -1,6 +1,6 @@
 ﻿#region
 
-using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -8,8 +8,6 @@ namespace UlteriusServer.Api.Network.Messages
 {
     public class Message
     {
-
-       
         public enum MessageType
         {
             Text,
@@ -21,21 +19,20 @@ namespace UlteriusServer.Api.Network.Messages
         public readonly MessageType Type;
 
 
-     
-        public Message(AuthClient authClient, byte[] data, MessageType type)
+        public Message(WebSocket remoteClient, byte[] data, MessageType type)
         {
-            AuthClient = authClient;
+            RemoteClient = remoteClient;
             Data = data;
             Type = type;
         }
 
-        public Message(AuthClient authClient, string json, MessageType type)
+        public Message(WebSocket remoteClient, string json, MessageType type)
         {
-            AuthClient = authClient;
+            RemoteClient = remoteClient;
             Json = json;
             Type = type;
         }
 
-        public AuthClient AuthClient { get; set; }
+        public WebSocket RemoteClient { get; set; }
     }
 }

--- a/RemoteTaskServer/Api/Network/Messages/MessageQueueManager.cs
+++ b/RemoteTaskServer/Api/Network/Messages/MessageQueueManager.cs
@@ -47,8 +47,9 @@ namespace UlteriusServer.Api.Network.Messages
         private async Task SendJsonPacket(Message packet)
         {
             var json = packet.Json;
-            var client = packet.AuthClient.Client;
-            if (client.IsConnected)
+
+            var client = packet.RemoteClient;
+            if (client != null && client.IsConnected)
             {
                 try
                 {
@@ -73,17 +74,14 @@ namespace UlteriusServer.Api.Network.Messages
         /// <returns></returns>
         private async Task SendBinaryPacket(Message packet)
         {
-            var authClient = packet.AuthClient;
-            if (authClient != null && authClient.Client.IsConnected)
+            var client = packet.RemoteClient;
+            if (client != null && client.IsConnected)
             {
                 try
                 {
-                    if (authClient.AesShook)
-                    {
-                        using (var memoryStream = new MemoryStream(packet.Data))
-                        using (var messageWriter = authClient.Client.CreateMessageWriter(WebSocketMessageType.Binary))
-                            await memoryStream.CopyToAsync(messageWriter);
-                    }
+                    using (var memoryStream = new MemoryStream(packet.Data))
+                    using (var messageWriter = client.CreateMessageWriter(WebSocketMessageType.Binary))
+                        await memoryStream.CopyToAsync(messageWriter);
                 }
                 catch (Exception e)
                 {

--- a/RemoteTaskServer/Api/Network/Messages/Packet.cs
+++ b/RemoteTaskServer/Api/Network/Messages/Packet.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using UlteriusServer.Api.Network.PacketHandlers;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 using static UlteriusServer.Api.Network.PacketManager;
 
 #endregion
@@ -16,6 +17,7 @@ namespace UlteriusServer.Api.Network.Messages
         private readonly Type _packetHandler;
         public List<object> Args;
         public AuthClient AuthClient;
+        public  WebSocket Client;
         public string EndPoint;
         public PacketTypes PacketType;
         public string SyncKey;
@@ -29,10 +31,11 @@ namespace UlteriusServer.Api.Network.Messages
         /// <param name="args"></param>
         /// <param name="packetType"></param>
         /// <param name="packetHandler"></param>
-        public Packet(AuthClient authClient, string endPoint, string syncKey, List<object> args, PacketTypes packetType,
+        public Packet(AuthClient authClient, WebSocket client, string endPoint, string syncKey, List<object> args, PacketTypes packetType,
             Type packetHandler)
         {
             AuthClient = authClient;
+            Client = client;
             EndPoint = endPoint;
             SyncKey = syncKey;
             Args = args;

--- a/RemoteTaskServer/Api/Network/PacketHandlers/CpuPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/CpuPacketHandler.cs
@@ -7,6 +7,7 @@ using OpenHardwareMonitor.Hardware;
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -15,8 +16,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class CpuPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void GetCpuInformation()
@@ -59,9 +61,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
   
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.RequestCpuInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/ErrorPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/ErrorPacketHandler.cs
@@ -2,6 +2,7 @@
 
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -10,14 +11,16 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class ErrorPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.InvalidOrEmptyPacket:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/FilePacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/FilePacketHandler.cs
@@ -10,6 +10,7 @@ using UlteriusServer.Api.Services.Network;
 using UlteriusServer.Utilities;
 using UlteriusServer.Utilities.Files;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 using static UlteriusServer.Api.Network.PacketManager;
 using File = System.IO.File;
 
@@ -29,7 +30,8 @@ namespace UlteriusServer.Api.Network.PacketHandlers
         private const int EVERYTHING_ERROR_INVALIDCALL = 7;
 
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
+        private WebSocket _client;
         private Packet _packet;
 
         public void CreateFileTree()
@@ -354,9 +356,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketTypes.SearchFiles:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/GpuPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/GpuPacketHandler.cs
@@ -7,6 +7,7 @@ using OpenHardwareMonitor.Hardware;
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 using static UlteriusServer.Api.Network.PacketManager;
 
 #endregion
@@ -16,8 +17,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     internal class GpuPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void GetGpuInformation()
@@ -92,9 +94,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketTypes.RequestGpuInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/NetworkPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/NetworkPacketHandler.cs
@@ -4,6 +4,7 @@ using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.Api.Services.Network;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 using static UlteriusServer.Api.Network.PacketManager;
 
 #endregion
@@ -13,8 +14,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class NetworkPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void GetNetworkInformation()
@@ -31,9 +33,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketTypes.RequestNetworkInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/OperatingSystemPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/OperatingSystemPacketHandler.cs
@@ -7,6 +7,7 @@ using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.Api.Services.System;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -15,8 +16,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class OperatingSystemPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void GetEventLogs()
@@ -48,9 +50,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.RequestOsInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/PluginPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/PluginPacketHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Plugins;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -12,7 +13,8 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class PluginPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
+        private WebSocket _client;
         private Packet _packet;
 
 
@@ -58,12 +60,12 @@ namespace UlteriusServer.Api.Network.PacketHandlers
                 var cleanedArgs = _packet.Args;
                 //remove guid from the arguments.
                 cleanedArgs.RemoveAt(0);
-                returnData = PluginHandler.StartPlugin(_client.Client, guid, cleanedArgs);
+                returnData = PluginHandler.StartPlugin(_client, guid, cleanedArgs);
                 pluginStarted = true;
             }
             else
             {
-                returnData = PluginHandler.StartPlugin(_client.Client, guid);
+                returnData = PluginHandler.StartPlugin(_client, guid);
                 pluginStarted = true;
             }
             var pluginResponse = new
@@ -77,9 +79,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.Plugin:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/ProcessPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/ProcessPacketHandler.cs
@@ -10,6 +10,7 @@ using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.Utilities;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -18,8 +19,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class ProcessPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void StartProcess()
@@ -136,9 +138,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.RequestProcessInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/ScreenSharePacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/ScreenSharePacketHandler.cs
@@ -2,6 +2,7 @@
 
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -11,8 +12,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     {
         private readonly ScreenShareService _shareService = UlteriusApiServer.ScreenShareService;
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void StopScreenShare()
@@ -88,9 +90,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.CheckScreenShare:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/SettingsPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/SettingsPacketHandler.cs
@@ -4,6 +4,7 @@ using System;
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Utilities;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -12,8 +13,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class SettingsPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void ChangeWebServerPort()
@@ -152,9 +154,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.ToggleWebServer:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/SystemPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/SystemPacketHandler.cs
@@ -3,6 +3,7 @@
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.Api.Network.Models;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -11,8 +12,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class SystemPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         public void GetSystemInformation()
@@ -22,9 +24,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client, _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.RequestSystemInformation:

--- a/RemoteTaskServer/Api/Network/PacketHandlers/WindowsPacketHandler.cs
+++ b/RemoteTaskServer/Api/Network/PacketHandlers/WindowsPacketHandler.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using UlteriusServer.Api.Network.Messages;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -16,8 +17,9 @@ namespace UlteriusServer.Api.Network.PacketHandlers
     public class WindowsPacketHandler : PacketHandler
     {
         private MessageBuilder _builder;
-        private AuthClient _client;
+        private AuthClient _authClient;
         private Packet _packet;
+        private WebSocket _client;
 
 
         private string GetUserTilePath(string username)
@@ -77,9 +79,10 @@ namespace UlteriusServer.Api.Network.PacketHandlers
 
         public override void HandlePacket(Packet packet)
         {
-            _client = packet.AuthClient;
+            _client = packet.Client;
+            _authClient = packet.AuthClient;
             _packet = packet;
-            _builder = new MessageBuilder(_client, _packet.EndPoint, _packet.SyncKey);
+            _builder = new MessageBuilder(_authClient, _client,  _packet.EndPoint, _packet.SyncKey);
             switch (_packet.PacketType)
             {
                 case PacketManager.PacketTypes.GetWindowsData:

--- a/RemoteTaskServer/Api/Network/PacketManager.cs
+++ b/RemoteTaskServer/Api/Network/PacketManager.cs
@@ -9,6 +9,7 @@ using UlteriusServer.Api.Network.PacketHandlers;
 using UlteriusServer.Utilities;
 using UlteriusServer.Utilities.Security;
 using UlteriusServer.WebSocketAPI.Authentication;
+using vtortola.WebSockets;
 
 #endregion
 
@@ -77,6 +78,7 @@ namespace UlteriusServer.Api.Network
 
         private readonly List<object> _args = new List<object>();
         private readonly AuthClient _authClient;
+        private readonly WebSocket _client;
         private readonly string _plainText = string.Empty;
         private string _endPoint;
         private Type _packetHandler;
@@ -88,9 +90,10 @@ namespace UlteriusServer.Api.Network
         /// </summary>
         /// <param name="authClient"></param>
         /// <param name="data"></param>
-        public PacketManager(AuthClient authClient, byte[] data)
+        public PacketManager(AuthClient authClient, WebSocket client, byte[] data)
         {
             _authClient = authClient;
+            _client = client;
             try
             {
                 var keyBytes = Encoding.UTF8.GetBytes(Rsa.SecureStringToString(authClient.AesKey));
@@ -109,10 +112,11 @@ namespace UlteriusServer.Api.Network
         /// </summary>
         /// <param name="authClient"></param>
         /// <param name="packetData"></param>
-        public PacketManager(AuthClient authClient, string packetData)
+        public PacketManager(AuthClient authClient, WebSocket client, string packetData)
         {
       
             _authClient = authClient;
+            _client = client;
             try
             {
                 if ((bool) Settings.Get("TaskServer").Encryption)
@@ -336,7 +340,7 @@ namespace UlteriusServer.Api.Network
                     var packetInfo = GetPacketInfo(_endPoint);
                     _packetHandler = packetInfo.Handler;
                     _packetType = packetInfo.Type;
-                    return new Packet(_authClient, _endPoint, _syncKey, _args, _packetType, _packetHandler);
+                    return new Packet(_authClient, _client, _endPoint, _syncKey, _args, _packetType, _packetHandler);
                 }
             }
             catch (Exception e)

--- a/RemoteTaskServer/Api/Services/System/FileSearchService.cs
+++ b/RemoteTaskServer/Api/Services/System/FileSearchService.cs
@@ -12,7 +12,7 @@ namespace UlteriusServer.Api.Services.System
     public class FileSearchService
     {
         private readonly string _cachePath;
-        private DatabaseController databaseController;
+        private DatabaseController _databaseController;
 
         public FileSearchService(string path)
         {
@@ -21,24 +21,24 @@ namespace UlteriusServer.Api.Services.System
 
         public string CurrentScanDrive()
         {
-            return databaseController.GetCurrentDrive();
+            return _databaseController.GetCurrentDrive();
         }
 
         public bool IsScanning()
         {
-            return databaseController.IsScanning();
+            return _databaseController.IsScanning();
         }
 
         public List<string> Search(string keyword)
         {
-            return databaseController?.Search(keyword);
+            return _databaseController?.Search(keyword);
         }
 
         public void Start()
         {
             Task.Run(() => {
-                databaseController = new DatabaseController(_cachePath);
-                databaseController.Start();
+                _databaseController = new DatabaseController(_cachePath);
+                _databaseController.Start();
                 Console.WriteLine("File Database Ready");
             });
         }

--- a/RemoteTaskServer/Api/Services/System/FileSearchService.cs
+++ b/RemoteTaskServer/Api/Services/System/FileSearchService.cs
@@ -1,8 +1,9 @@
 ﻿#region
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using UlteriusFileSearch;
+using UlteriusServer.Utilities.Files.Database;
 
 #endregion
 
@@ -10,33 +11,36 @@ namespace UlteriusServer.Api.Services.System
 {
     public class FileSearchService
     {
-        private readonly string _path;
-        private SearchService fileSearch;
+        private readonly string _cachePath;
+        private DatabaseController databaseController;
 
         public FileSearchService(string path)
         {
-            _path = path;
+            _cachePath = path;
         }
 
         public string CurrentScanDrive()
         {
-            return fileSearch.CurrentScanDrive();
+            return databaseController.GetCurrentDrive();
         }
 
         public bool IsScanning()
         {
-            return fileSearch.IsScanning();
+            return databaseController.IsScanning();
         }
 
         public List<string> Search(string keyword)
         {
-            return fileSearch.Search(keyword);
+            return databaseController?.Search(keyword);
         }
 
         public void Start()
         {
-            fileSearch = new SearchService(_path);
-            Task.Run(() => { fileSearch.Configure(); });
+            Task.Run(() => {
+                databaseController = new DatabaseController(_cachePath);
+                databaseController.Start();
+                Console.WriteLine("File Database Ready");
+            });
         }
     }
 }

--- a/RemoteTaskServer/Api/Services/System/SystemService.cs
+++ b/RemoteTaskServer/Api/Services/System/SystemService.cs
@@ -285,7 +285,6 @@ namespace UlteriusServer.Api.Services.System
                 var model = drive["Model"].ToString().Trim();
                 if (type.Equals("IDE"))
                 {
-                    Console.WriteLine(model);
                     var driveData = di[iDriveIndex];
                     driveInfo.Model = model;
                     driveInfo.Name = driveData.Name;

--- a/RemoteTaskServer/Api/Services/Update/ClientUpdateService.cs
+++ b/RemoteTaskServer/Api/Services/Update/ClientUpdateService.cs
@@ -14,12 +14,13 @@ namespace UlteriusServer.Api.Services.Update
 {
     public class ClientUpdateService
     {
-        public ClientUpdateService()
+    
+
+        public void Start()
         {
             var updaterChecker = new Task(Updater);
             updaterChecker.Start();
         }
-
         private async void Updater()
         {
             while (true)

--- a/RemoteTaskServer/Api/UlteriusApiServer.cs
+++ b/RemoteTaskServer/Api/UlteriusApiServer.cs
@@ -36,15 +36,16 @@ namespace UlteriusServer.Api
         /// </summary>
         public static void Start()
         {
+            var clientUpdateService = new ClientUpdateService();
+            clientUpdateService.Start();
+            FileSearchService = new FileSearchService(Path.Combine(AppEnvironment.DataPath, "fileindex.bin"));
+            FileSearchService.Start();
+
             var apiPort = (int) Settings.Get("TaskServer").TaskServerPort;
             AllClients = new ConcurrentDictionary<Guid, AuthClient>();
             ScreenShareService = new ScreenShareService();
-            FileSearchService = new FileSearchService(Path.Combine(AppEnvironment.DataPath, "fileindex.bin"));
-            FileSearchService.Start();
             var address = NetworkService.GetAddress();
-            var endPoints = new List<IPEndPoint> {new IPEndPoint(address, apiPort), new IPEndPoint(address, 29999)};
-
-
+            var endPoints = new List<IPEndPoint> {new IPEndPoint(address, apiPort)};
             var server = new WebSocketEventListener(endPoints, new WebSocketListenerOptions
             {
                 PingTimeout = TimeSpan.FromSeconds(15),

--- a/RemoteTaskServer/Api/UlteriusApiServer.cs
+++ b/RemoteTaskServer/Api/UlteriusApiServer.cs
@@ -37,15 +37,10 @@ namespace UlteriusServer.Api
         public static void Start()
         {
             var apiPort = (int) Settings.Get("TaskServer").TaskServerPort;
-
-
             AllClients = new ConcurrentDictionary<Guid, AuthClient>();
-            var clientUpdateService = new ClientUpdateService();
             ScreenShareService = new ScreenShareService();
             FileSearchService = new FileSearchService(Path.Combine(AppEnvironment.DataPath, "fileindex.bin"));
             FileSearchService.Start();
-
-            var cancellation = new CancellationTokenSource();
             var address = NetworkService.GetAddress();
             var endPoints = new List<IPEndPoint> {new IPEndPoint(address, apiPort), new IPEndPoint(address, 29999)};
 

--- a/RemoteTaskServer/Api/Win32/Win32Exception.cs
+++ b/RemoteTaskServer/Api/Win32/Win32Exception.cs
@@ -1,0 +1,100 @@
+﻿#region
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Security;
+using System.Security.Permissions;
+using System.Text;
+
+#endregion
+
+namespace UlteriusServer.Api.Win32
+{
+    [SuppressUnmanagedCodeSecurity]
+    [HostProtection(SecurityAction.LinkDemand, SharedState = true)]
+    [Serializable]
+    internal class Win32Exception : ExternalException
+    {
+        // Microsoft.Win32.NativeMethods
+        public static readonly HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Win32Exception() : this(Marshal.GetLastWin32Error())
+        {
+        }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Win32Exception(int error) : this(error, GetErrorMessage(error))
+        {
+        }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Win32Exception(int error, string message) : base(message)
+        {
+            NativeErrorCode = error;
+        }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message)
+        {
+        }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public Win32Exception(string message, Exception innerException) : base(message, innerException)
+        {
+            NativeErrorCode = Marshal.GetLastWin32Error();
+        }
+
+        [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        protected Win32Exception(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            //IntSecurity.UnmanagedCode.Demand();
+            NativeErrorCode = info.GetInt32("NativeErrorCode");
+        }
+
+        public int NativeErrorCode { get; }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+            info.AddValue("NativeErrorCode", NativeErrorCode);
+            base.GetObjectData(info, context);
+        }
+
+        // Microsoft.Win32.SafeNativeMethods
+        [DllImport("kernel32.dll", BestFitMapping = true, CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int FormatMessage(int dwFlags, HandleRef lpSource, int dwMessageId, int dwLanguageId,
+            StringBuilder lpBuffer, int nSize, IntPtr arguments);
+
+        private static string GetErrorMessage(int error)
+        {
+            string result;
+            var stringBuilder = new StringBuilder(256);
+            var num = FormatMessage(12800, NullHandleRef, error, 0, stringBuilder, stringBuilder.Capacity + 1,
+                IntPtr.Zero);
+            if (num != 0)
+            {
+                int i;
+                for (i = stringBuilder.Length; i > 0; i--)
+                {
+                    var c = stringBuilder[i - 1];
+                    if (c > ' ' && c != '.')
+                    {
+                        break;
+                    }
+                }
+                result = stringBuilder.ToString(0, i);
+            }
+            else
+            {
+                result = "Unknown error (0x" + Convert.ToString(error, 16) + ")";
+            }
+            return result;
+        }
+    }
+}

--- a/RemoteTaskServer/Api/Win32/WinApi.cs
+++ b/RemoteTaskServer/Api/Win32/WinApi.cs
@@ -1,0 +1,193 @@
+﻿#region
+
+using System;
+using System.Runtime.InteropServices;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+
+#endregion
+
+namespace UlteriusServer.Api.Win32
+{
+    internal class WinApi
+    {
+        public enum FileIdType
+        {
+            FileIdType = 0,
+            ObjectIdType = 1,
+            ExtendedFileIdType = 2
+        }
+
+        public const uint GenericRead = 0x80000000;
+        public const uint GenericWrite = 0x40000000;
+        public const uint FileShareRead = 0x00000001;
+        public const uint FileShareWrite = 0x00000002;
+        public const uint FileAttributeDirectory = 0x00000010;
+        public const uint OpenExisting = 3;
+        public const uint FileFlagBackupSemantics = 0x02000000;
+        public const int InvalidHandleValue = -1;
+        public const uint FsctlQueryUsnJournal = 0x000900f4;
+        public const uint FsctlEnumUsnData = 0x000900b3;
+        public const uint FsctlCreateUsnJournal = 0x000900e7;
+
+        [DllImport("kernel32.dll")]
+        public static extern uint GetCompressedFileSizeW([In, MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            [Out, MarshalAs(UnmanagedType.U4)] out uint lpFileSizeHigh);
+
+        [DllImport("kernel32.dll", SetLastError = true, PreserveSig = true)]
+        public static extern int GetDiskFreeSpaceW([In, MarshalAs(UnmanagedType.LPWStr)] string lpRootPathName,
+            out uint lpSectorsPerCluster, out uint lpBytesPerSector, out uint lpNumberOfFreeClusters,
+            out uint lpTotalNumberOfClusters);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr OpenFileById(IntPtr hFile, FileIdDescriptor desc, uint dwDesiredAccess,
+            int dwShareMode, int lpSecurityAttributes, int dwFlagas);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess,
+            uint dwShareMode, IntPtr lpSecurityAttributes,
+            uint dwCreationDisposition, uint dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetFileInformationByHandle(IntPtr hFile,
+            out ByHandleFileInformation lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true, CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DeviceIoControl(IntPtr hDevice,
+            uint dwIoControlCode,
+            IntPtr lpInBuffer, int nInBufferSize,
+            out UsnJournalData lpOutBuffer, int nOutBufferSize,
+            out uint lpBytesReturned, IntPtr lpOverlapped);
+
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true, CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DeviceIoControl(IntPtr hDevice,
+            uint dwIoControlCode,
+            IntPtr lpInBuffer, int nInBufferSize,
+            IntPtr lpOutBuffer, int nOutBufferSize,
+            out uint lpBytesReturned, IntPtr lpOverlapped);
+
+        [DllImport("kernel32.dll")]
+        public static extern void ZeroMemory(IntPtr ptr, int size);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr FindFirstFile(string lpFileName, out Win32FindData lpFindFileData);
+
+        public static uint GetFileSizeA(string filename)
+        {
+            Win32FindData findData;
+            FindFirstFile(filename, out findData);
+            return findData.nFileSizeLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct ByHandleFileInformation
+        {
+            public uint FileAttributes;
+            public Filetime CreationTime;
+            public Filetime LastAccessTime;
+            public Filetime LastWriteTime;
+            public uint VolumeSerialNumber;
+            public uint FileSizeHigh;
+            public uint FileSizeLow;
+            public uint NumberOfLinks;
+            public uint FileIndexHigh;
+            public uint FileIndexLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct Filetime
+        {
+            public uint DateTimeLow;
+            public uint DateTimeHigh;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        private struct Win32FindData
+        {
+            public readonly uint dwFileAttributes;
+            public readonly FILETIME ftCreationTime;
+            public readonly FILETIME ftLastAccessTime;
+            public readonly FILETIME ftLastWriteTime;
+            public readonly uint nFileSizeHigh;
+            public readonly uint nFileSizeLow;
+            public readonly uint dwReserved0;
+            public readonly uint dwReserved1;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public readonly string cFileName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
+            public readonly string cAlternateFileName;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct UsnJournalData
+        {
+            public ulong UsnJournalID;
+            public long FirstUsn;
+            public long NextUsn;
+            public long LowestValidUsn;
+            public long MaxUsn;
+            public ulong MaximumSize;
+            public ulong AllocationDelta;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct MftEnumData
+        {
+            public ulong StartFileReferenceNumber;
+            public long LowUsn;
+            public long HighUsn;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct CreateUsnJournalData
+        {
+            public ulong MaximumSize;
+            public ulong AllocationDelta;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct FileIdDescriptor
+        {
+            [FieldOffset(0)]
+            public uint dwSize;
+            [FieldOffset(4)]
+            public FileIdType type;
+            [FieldOffset(8)]
+            public Guid guid;
+        }
+
+        public class UsnRecord
+        {
+            private const int FrOffset = 8;
+            private const int PfrOffset = 16;
+            private const int FaOffset = 52;
+            private const int FnlOffset = 56;
+            private const int FnOffset = 58;
+            public uint FileAttributes;
+            public string FileName;
+            public int FileNameLength;
+            public int FileNameOffset;
+            public ulong FileReferenceNumber;
+            public ulong ParentFileReferenceNumber;
+            public uint RecordLength;
+
+            public UsnRecord(IntPtr p)
+            {
+                RecordLength = (uint)Marshal.ReadInt32(p);
+                FileReferenceNumber = (ulong)Marshal.ReadInt64(p, FrOffset);
+                ParentFileReferenceNumber = (ulong)Marshal.ReadInt64(p, PfrOffset);
+                FileAttributes = (uint)Marshal.ReadInt32(p, FaOffset);
+                FileNameLength = Marshal.ReadInt16(p, FnlOffset);
+                FileNameOffset = Marshal.ReadInt16(p, FnOffset);
+                FileName = Marshal.PtrToStringUni(new IntPtr(p.ToInt64() + FileNameOffset), FileNameLength / sizeof(char));
+            }
+        }
+    }
+}

--- a/RemoteTaskServer/App.config
+++ b/RemoteTaskServer/App.config
@@ -25,11 +25,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="vtortola.WebSockets" publicKeyToken="7f78616efb4a208d" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.2" newVersion="2.2.0.2" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.1.0" newVersion="2.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="vtortola.WebSockets.Rfc6455" publicKeyToken="7f78616efb4a208d" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.2" newVersion="2.2.0.2" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.1.0" newVersion="2.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="vtortola.WebSockets.Deflate" publicKeyToken="7f78616efb4a208d" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.1.0" newVersion="2.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RemoteTaskServer/TerminalServer/Messaging/WebSocketHandler.cs
+++ b/RemoteTaskServer/TerminalServer/Messaging/WebSocketHandler.cs
@@ -109,13 +109,6 @@ namespace UlteriusServer.TerminalServer.Messaging
             return (Guid) ws.HttpRequest.Items[WebSocketQueueServer.ConnectionIdKey];
         }
 
-        private static AuthClient AddTerminalClient(WebSocket ws)
-        {
-            var client = new AuthClient(ws);
-
-            return client;
-        }
-
         private static Guid GetSessionId(WebSocket ws)
         {
             var sessionId = Guid.Empty;

--- a/RemoteTaskServer/Ulterius.cs
+++ b/RemoteTaskServer/Ulterius.cs
@@ -55,7 +55,7 @@ namespace UlteriusServer
         /// </summary>
         private void Setup()
         {
-            HideWindow();
+            //HideWindow();
             Console.WriteLine("Creating settings");
             Settings.Initialize("Config.json");
             Console.WriteLine("Configuring up server");

--- a/RemoteTaskServer/UlteriusServer.csproj
+++ b/RemoteTaskServer/UlteriusServer.csproj
@@ -54,6 +54,7 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup />
@@ -171,9 +172,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UlteriusFileSearch">
-      <HintPath>extensions\UlteriusFileSearch.dll</HintPath>
-    </Reference>
     <Reference Include="UlteriusPluginBase, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>extensions\UlteriusPluginBase.dll</HintPath>
@@ -181,22 +179,24 @@
     <Reference Include="UlteriusScreenShare">
       <HintPath>extensions\UlteriusScreenShare.dll</HintPath>
     </Reference>
-    <Reference Include="vtortola.WebSockets, Version=2.2.0.3, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
-      <HintPath>..\packages\vtortola.WebSocketListener.2.2.0.3\lib\net45\vtortola.WebSockets.dll</HintPath>
+    <Reference Include="vtortola.WebSockets, Version=2.2.1.0, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
+      <HintPath>..\packages\vtortola.WebSocketListener.2.2.1.0\lib\net45\vtortola.WebSockets.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="vtortola.WebSockets.Deflate, Version=2.2.0.3, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
-      <HintPath>..\packages\vtortola.WebSocketListener.2.2.0.3\lib\net45\vtortola.WebSockets.Deflate.dll</HintPath>
+    <Reference Include="vtortola.WebSockets.Deflate, Version=2.2.1.0, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
+      <HintPath>..\packages\vtortola.WebSocketListener.2.2.1.0\lib\net45\vtortola.WebSockets.Deflate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="vtortola.WebSockets.Rfc6455, Version=2.2.0.3, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
-      <HintPath>..\packages\vtortola.WebSocketListener.2.2.0.3\lib\net45\vtortola.WebSockets.Rfc6455.dll</HintPath>
+    <Reference Include="vtortola.WebSockets.Rfc6455, Version=2.2.1.0, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
+      <HintPath>..\packages\vtortola.WebSocketListener.2.2.1.0\lib\net45\vtortola.WebSockets.Rfc6455.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api\Services\Update\ClientUpdateService.cs" />
+    <Compile Include="Api\Win32\Win32Exception.cs" />
+    <Compile Include="Api\Win32\WinApi.cs" />
     <Compile Include="Plugins\PluginHost.cs" />
     <Compile Include="Api\Network\Messages\Message.cs" />
     <Compile Include="Api\Network\Messages\MessageQueueManager.cs" />
@@ -204,6 +204,11 @@
     <Compile Include="Ulterius.cs" />
     <Compile Include="Utilities\Drive\Disk.cs" />
     <Compile Include="Utilities\Drive\Smart.cs" />
+    <Compile Include="Utilities\Files\Database\DatabaseController.cs" />
+    <Compile Include="Utilities\Files\Database\DatabaseManager.cs" />
+    <Compile Include="Utilities\Files\Ntfs\FileEntry.cs" />
+    <Compile Include="Utilities\Files\Ntfs\MftEnumerator.cs" />
+    <Compile Include="Utilities\Files\Ntfs\Volume.cs" />
     <Compile Include="Utilities\Security\WindowsAuth.cs" />
     <Compile Include="WebSocketAPI\Authentication\AuthClient.cs" />
     <Compile Include="Forms\Utilities\UlteriusTray.cs" />
@@ -334,6 +339,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="bin\Debug\" />
+    <Folder Include="Utilities\Files\Models\" />
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="NetFwTypeLib">

--- a/RemoteTaskServer/UlteriusServer.csproj
+++ b/RemoteTaskServer/UlteriusServer.csproj
@@ -280,6 +280,7 @@
     <Compile Include="Utilities\Trace.cs" />
     <Compile Include="WebCams\WebCamManager.cs" />
     <Compile Include="WebServer\MultipartParser.cs" />
+    <Compile Include="WebSocketAPI\Authentication\CookieManager.cs" />
     <Compile Include="WebSocketAPI\WebSocketEventListener.cs" />
     <Compile Include="Api\Network\Models\DriveInformation.cs" />
     <Compile Include="Api\Network\Models\SystemInformation.cs" />

--- a/RemoteTaskServer/Utilities/Files/Database/DatabaseController.cs
+++ b/RemoteTaskServer/Utilities/Files/Database/DatabaseController.cs
@@ -1,0 +1,69 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+
+#endregion
+
+namespace UlteriusServer.Utilities.Files.Database
+{
+    //keeps everything together
+    internal class DatabaseController
+    {
+        private readonly DatabaseManager _databaseManager;
+        private readonly string _path;
+
+        public DatabaseController(string path)
+        {
+            _path = path;
+            _databaseManager = new DatabaseManager(path);
+        }
+
+
+
+        public string GetCurrentDrive()
+        {
+            return _databaseManager.CurrentDrive;
+        }
+
+        public bool IsScanning()
+        {
+            return _databaseManager.Scanning;
+        }
+
+        private void Scan()
+        {
+            _databaseManager.Scanning = true;
+            _databaseManager.CreateDatabase();
+            _databaseManager.Scanning = false;
+        }
+
+        public List<string> Search(string keyword)
+        {
+
+            return _databaseManager.Search(keyword);
+        }
+
+        public bool Refresh()
+        {
+            return _databaseManager.CreateDatabase();
+        }
+
+        public void Start()
+        {
+            if (System.IO.File.Exists(_path))
+            {
+                if (_databaseManager.OutOfSync())
+                {
+
+                    Scan();
+                }
+            }
+            else
+            {
+                Console.WriteLine("Getting ready to scan");
+                Scan();
+            }
+        }
+    }
+}

--- a/RemoteTaskServer/Utilities/Files/Database/DatabaseManager.cs
+++ b/RemoteTaskServer/Utilities/Files/Database/DatabaseManager.cs
@@ -1,0 +1,167 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Microsoft.VisualBasic;
+using Microsoft.VisualBasic.CompilerServices;
+using UlteriusServer.Utilities.Files.Ntfs;
+
+#endregion
+
+namespace UlteriusServer.Utilities.Files.Database
+{
+    //handles data saving/loading, appending/reading
+    internal class DatabaseManager
+    {
+        private readonly string _path;
+
+
+        public DatabaseManager(string path)
+        {
+            _path = path;
+        }
+
+        public string CurrentDrive { get; set; }
+
+
+
+
+
+        public List<string> Search(string value)
+        {
+            var results = new List<string>();
+            using (var file = System.IO.File.OpenRead(_path))
+            using (var deflate = new DeflateStream(file, CompressionMode.Decompress))
+            using (var reader = new BinaryReader(deflate))
+            {
+                //read the metadata
+                var lastUpdate = reader.ReadInt64();
+                //read until exception
+                while (true)
+                {
+                    try
+                    {
+                        var fileNameLength = reader.ReadInt32();
+                        var fileName = Encoding.UTF8.GetString(reader.ReadBytes(fileNameLength));
+                        var directoryLength = reader.ReadInt32();
+                        var directory = Encoding.UTF8.GetString(reader.ReadBytes(directoryLength));
+                        var size = reader.ReadInt64();
+                        if (Operators.LikeString(fileName, $"*{value}*", CompareMethod.Text))
+                        {
+                            results.Add(Path.Combine(directory, fileName));
+                        }
+                    }
+                    catch (EndOfStreamException e)
+                    {
+
+                        break;
+                    }
+                }
+
+            }
+            return results;
+        }
+
+        public bool OutOfSync()
+        {
+            return NeedsUpdate();
+        }
+
+        private DateTime UnixTimeStampToDateTime(double unixTimeStamp)
+        {
+            // Unix timestamp is seconds past epoch
+            var dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            dtDateTime = dtDateTime.AddSeconds(unixTimeStamp).ToLocalTime();
+            return dtDateTime;
+        }
+
+
+        private bool NeedsUpdate()
+        {
+            using (var file = System.IO.File.OpenRead(_path))
+            using (var deflate = new DeflateStream(file, CompressionMode.Decompress))
+            using (var reader = new BinaryReader(deflate))
+            {
+                try
+                {
+                    var lastUpdate = UnixTimeStampToDateTime(reader.ReadInt64());
+
+                    var hours = (DateTime.Now - lastUpdate).TotalHours;
+                    //update the DB once every 24 hours
+                    if (hours > 24)
+                    {
+
+                        return true;
+                    }
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Database broke, redo.");
+                    return true;
+                }
+                return false;
+            }
+        }
+
+
+        public bool CreateDatabase()
+        {
+            using (var file = System.IO.File.Create(_path))
+            using (var deflate = new DeflateStream(file, CompressionMode.Compress))
+            using (var writer = new BinaryWriter(deflate))
+            {
+                var dateTime = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds;
+                writer.Write(dateTime);
+                var drives = Directory.GetLogicalDrives();
+                foreach (var drive in drives)
+                {
+                    try
+                    {
+                        CurrentDrive = drive;
+                        Scanning = true;
+                        var driveName = drive.Replace("\\", "").Replace("/", "");
+                        Console.WriteLine("scanning " + driveName);
+                        var data = new MftEnumerator(driveName);
+                        foreach (var currentFile in data)
+                        {
+                            if (currentFile != null)
+                            {
+                                try
+                                {
+                                    var fileName = Encoding.UTF8.GetBytes(Path.GetFileName(currentFile));
+                                    var directory = Encoding.UTF8.GetBytes(Path.GetDirectoryName(currentFile) ?? "null");
+                                    //slows down the scan
+
+                                    //  long size = WinApi.GetFileSizeA(currentFile);
+                                    long size = -1;
+
+                                    writer.Write(fileName.Length);
+                                    writer.Write(fileName);
+                                    writer.Write(directory.Length);
+                                    writer.Write(directory);
+                                    writer.Write(size);
+                                }
+                                catch (Exception)
+                                {
+                                    //path too long
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception)
+                    {
+
+                        Scanning = false;
+                    }
+                }
+                Scanning = false;
+                return true;
+            }
+        }
+
+        public bool Scanning { get; set; }
+    }
+}

--- a/RemoteTaskServer/Utilities/Files/Ntfs/FileEntry.cs
+++ b/RemoteTaskServer/Utilities/Files/Ntfs/FileEntry.cs
@@ -1,0 +1,28 @@
+﻿#region
+
+using System;
+
+#endregion
+
+namespace UlteriusServer.Utilities.Files.Ntfs
+{
+    internal class FileEntry
+    {
+        public FileEntry(string name, ulong parentFrn)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                Name = name;
+            }
+            else
+            {
+                throw new ArgumentException("Invalid argument: null or Length = zero", nameof(name));
+            }
+            ParentFrn = parentFrn;
+        }
+
+        public string Name { get; set; }
+
+        public ulong ParentFrn { get; set; }
+    }
+}

--- a/RemoteTaskServer/Utilities/Files/Ntfs/MftEnumerator.cs
+++ b/RemoteTaskServer/Utilities/Files/Ntfs/MftEnumerator.cs
@@ -1,0 +1,85 @@
+﻿#region
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+#endregion
+
+namespace UlteriusServer.Utilities.Files.Ntfs
+{
+    public class MftEnumerator : IEnumerable<string>
+    {
+        private readonly string _volume;
+        private Dictionary<ulong, FileEntry> _files;
+        private Dictionary<ulong, FileEntry> _folders;
+
+        public MftEnumerator(string volume) //volume is "c:" format (no quotes)
+        {
+            _volume = volume;
+        }
+
+        public int Count
+        {
+            get
+            {
+                Init();
+                return _files.Values.Count;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            Init();
+            var path = new List<string>(); //path fragment collector
+            foreach (var f in _files.Values)
+            {
+                path.Clear();
+                var p = f;
+                var dp = -1; //max path length counter to avoid inifinte loops
+
+                do
+                {
+                    if (p.ParentFrn != 0)
+                    {
+                        path.Add(p.Name);
+                    }
+                    if (_files.ContainsKey(p.ParentFrn))
+                    {
+                        p = _files[p.ParentFrn];
+                    }
+                    else if (_folders.ContainsKey(p.ParentFrn))
+                    {
+                        p = _folders[p.ParentFrn];
+                    }
+                    else
+                    {
+                        p = null;
+                    }
+                } while (p != null && ++dp < 1000);
+
+                if (path.Count != 0)
+                {
+                    path.Reverse();
+                    var file = _volume + '\\' + Path.Combine(path.ToArray());
+                    yield return file;
+                }
+            }
+        }
+
+        private void Init()
+        {
+            if (_files != null)
+            {
+                return;
+            }
+            var ntfs = new Volume();
+            ntfs.EnumerateVolume(_volume, null, out _files, out _folders);
+        }
+    }
+}

--- a/RemoteTaskServer/Utilities/Files/Ntfs/Volume.cs
+++ b/RemoteTaskServer/Utilities/Files/Ntfs/Volume.cs
@@ -1,0 +1,253 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using UlteriusServer.Api.Win32;
+
+#endregion
+
+namespace UlteriusServer.Utilities.Files.Ntfs
+{
+    internal class Volume
+    {
+        public void EnumerateVolume(string drive, HashSet<string> fileExtensions
+            , out Dictionary<ulong, FileEntry> files
+            , out Dictionary<ulong, FileEntry> directories
+            )
+        {
+            directories = new Dictionary<ulong, FileEntry>();
+            files = new Dictionary<ulong, FileEntry>();
+            var medBuffer = IntPtr.Zero;
+            var changeJournalRootHandle = IntPtr.Zero;
+            try
+            {
+                GetRootFrnEntry(drive, directories);
+                GetRootHandle(drive, out changeJournalRootHandle);
+                CreateChangeJournal(changeJournalRootHandle);
+                SetupMFT_Enum_DataBuffer(ref medBuffer, changeJournalRootHandle);
+                EnumerateFiles(medBuffer, ref files, fileExtensions, directories, changeJournalRootHandle);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message, e);
+                var innerException = e.InnerException;
+                while (innerException != null)
+                {
+                    Console.WriteLine(innerException.Message, innerException);
+                    innerException = innerException.InnerException;
+                }
+                throw new ApplicationException("Error in EnumerateVolume()", e);
+            }
+            finally
+            {
+
+                if (changeJournalRootHandle.ToInt64() != WinApi.InvalidHandleValue)
+                {
+                    WinApi.CloseHandle(changeJournalRootHandle);
+                }
+                if (medBuffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(medBuffer);
+                }
+            }
+        }
+
+        private void GetRootFrnEntry(string drive, Dictionary<ulong, FileEntry> directories)
+        {
+            var driveRoot = string.Concat("\\\\.\\", drive);
+            driveRoot = string.Concat(driveRoot, Path.DirectorySeparatorChar);
+            var hRoot = WinApi.CreateFile(driveRoot,
+                0,
+                WinApi.FileShareRead | WinApi.FileShareWrite,
+                IntPtr.Zero,
+                WinApi.OpenExisting,
+                WinApi.FileFlagBackupSemantics,
+                IntPtr.Zero
+                );
+
+            if (hRoot.ToInt64() != WinApi.InvalidHandleValue)
+            {
+                WinApi.ByHandleFileInformation fi;
+                var bRtn = WinApi.GetFileInformationByHandle(hRoot, out fi);
+                if (bRtn)
+                {
+                    ulong fileIndexHigh = fi.FileIndexHigh;
+                    var indexRoot = (fileIndexHigh << 32) | fi.FileIndexLow;
+
+                    var f = new FileEntry(driveRoot, 0);
+                    directories.Add(indexRoot, f);
+                }
+                else
+                {
+                    throw new IOException("GetFileInformationbyHandle() returned invalid handle",
+                        new Win32Exception(Marshal.GetLastWin32Error()));
+                }
+                WinApi.CloseHandle(hRoot);
+            }
+            else
+            {
+                throw new IOException("Unable to get root frn entry", new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+        }
+
+        private void GetRootHandle(string drive, out IntPtr changeJournalRootHandle)
+        {
+            var vol = string.Concat("\\\\.\\", drive);
+            changeJournalRootHandle = WinApi.CreateFile(vol,
+                WinApi.GenericRead | WinApi.GenericWrite,
+                WinApi.FileShareRead | WinApi.FileShareWrite,
+                IntPtr.Zero,
+                WinApi.OpenExisting,
+                0,
+                IntPtr.Zero);
+            if (changeJournalRootHandle.ToInt64() == WinApi.InvalidHandleValue)
+            {
+                throw new IOException("CreateFile() returned invalid handle",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+        }
+
+
+        private unsafe void EnumerateFiles(IntPtr medBuffer
+            , ref Dictionary<ulong, FileEntry> files
+            , HashSet<string> fileExtensions
+            , Dictionary<ulong, FileEntry> directories
+            , IntPtr changeJournalRootHandle
+            )
+        {
+            var pData = Marshal.AllocHGlobal(sizeof(ulong) + 0x10000);
+            WinApi.ZeroMemory(pData, sizeof(ulong) + 0x10000);
+            uint outBytesReturned;
+
+            while (WinApi.DeviceIoControl(changeJournalRootHandle, WinApi.FsctlEnumUsnData, medBuffer,
+                sizeof(WinApi.MftEnumData), pData, sizeof(ulong) + 0x10000, out outBytesReturned,
+                IntPtr.Zero))
+            {
+                var pUsnRecord = new IntPtr(pData.ToInt64() + sizeof(long));
+                while (outBytesReturned > 60)
+                {
+                    var usn = new WinApi.UsnRecord(pUsnRecord);
+
+                    if (0 != (usn.FileAttributes & WinApi.FileAttributeDirectory))
+                    {
+                        //
+                        // handle directories
+                        //
+                        if (!directories.ContainsKey(usn.FileReferenceNumber))
+                        {
+                            directories.Add(usn.FileReferenceNumber,
+                                new FileEntry(usn.FileName, usn.ParentFileReferenceNumber));
+                        }
+                        else
+                        {
+                            // this is debug code and should be removed when we are certain that
+                            // duplicate frn's don't exist on a given drive.  To date, this exception has
+                            // never been thrown.  Removing this code improves performance....
+                            throw new Exception($"Duplicate FRN: {usn.FileReferenceNumber} for {usn.FileName}"
+                                );
+                        }
+                    }
+                    else
+                    {
+                        //
+                        // handle files
+                        //
+                        var add = true;
+                        if (fileExtensions != null)
+                        {
+                            var s = Path.GetExtension(usn.FileName);
+                            add = fileExtensions.Contains(s);
+                        }
+                        if (add)
+                        {
+                            if (!files.ContainsKey(usn.FileReferenceNumber))
+                            {
+                                files.Add(usn.FileReferenceNumber,
+                                    new FileEntry(usn.FileName, usn.ParentFileReferenceNumber));
+                            }
+                            else
+                            {
+                                var frn = files[usn.FileReferenceNumber];
+
+                                if (0 != string.Compare(usn.FileName, frn.Name, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    Console.WriteLine(
+                                        $"Attempt to add duplicate file reference number: {usn.FileReferenceNumber} for file {usn.FileName}, file from index {frn.Name}");
+                                    throw new Exception(
+                                        $"Duplicate FRN: {usn.FileReferenceNumber} for {usn.FileName}"
+                                        );
+                                }
+                            }
+                        }
+                    }
+                    pUsnRecord = new IntPtr(pUsnRecord.ToInt64() + usn.RecordLength);
+                    outBytesReturned -= usn.RecordLength;
+                }
+                Marshal.WriteInt64(medBuffer, Marshal.ReadInt64(pData, 0));
+            }
+            Marshal.FreeHGlobal(pData);
+        }
+
+        private void CreateChangeJournal(IntPtr changeJournalRootHandle)
+        {
+            // This function creates a journal on the volume. If a journal already
+            // exists this function will adjust the MaximumSize and AllocationDelta
+            // parameters of the journal
+            ulong MaximumSize = 0x800000;
+            ulong AllocationDelta = 0x100000;
+            uint cb;
+            WinApi.CreateUsnJournalData cujd;
+            cujd.MaximumSize = MaximumSize;
+            cujd.AllocationDelta = AllocationDelta;
+
+            var sizeCujd = Marshal.SizeOf(cujd);
+            var cujdBuffer = Marshal.AllocHGlobal(sizeCujd);
+            WinApi.ZeroMemory(cujdBuffer, sizeCujd);
+            Marshal.StructureToPtr(cujd, cujdBuffer, true);
+
+            var fOk = WinApi.DeviceIoControl(changeJournalRootHandle, WinApi.FsctlCreateUsnJournal,
+                cujdBuffer, sizeCujd, IntPtr.Zero, 0, out cb, IntPtr.Zero);
+            if (!fOk)
+            {
+                throw new IOException("DeviceIoControl() returned false",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+        }
+
+
+        private unsafe void SetupMFT_Enum_DataBuffer(ref IntPtr medBuffer, IntPtr changeJournalRootHandle)
+        {
+            uint bytesReturned;
+            var ujd = new WinApi.UsnJournalData();
+
+            var bOk = WinApi.DeviceIoControl(
+                changeJournalRootHandle, // Handle to drive
+                WinApi.FsctlQueryUsnJournal, // IO Control Code
+                IntPtr.Zero, // In Buffer
+                0, // In Buffer Size
+                out ujd, // Out Buffer
+                sizeof(WinApi.UsnJournalData), // Size Of Out Buffer
+                out bytesReturned, // Bytes Returned
+                IntPtr.Zero // lpOverlapped
+                );
+            if (bOk)
+            {
+                WinApi.MftEnumData med;
+                med.StartFileReferenceNumber = 0;
+                med.LowUsn = 0;
+                med.HighUsn = ujd.NextUsn;
+                var sizeMftEnumData = Marshal.SizeOf(med);
+                medBuffer = Marshal.AllocHGlobal(sizeMftEnumData);
+                WinApi.ZeroMemory(medBuffer, sizeMftEnumData);
+                Marshal.StructureToPtr(med, medBuffer, true);
+            }
+            else
+            {
+                throw new IOException("DeviceIoControl() returned false",
+                    new Win32Exception(Marshal.GetLastWin32Error()));
+            }
+        }
+    }
+}

--- a/RemoteTaskServer/Utilities/Tools.cs
+++ b/RemoteTaskServer/Utilities/Tools.cs
@@ -260,11 +260,11 @@ namespace UlteriusServer.Utilities
 
         public static void ConfigureServer()
         {
-            var filestream = new FileStream(Path.Combine(AppEnvironment.DataPath, "server.log"),
-                FileMode.Create);
-            var streamwriter = new StreamWriter(filestream) {AutoFlush = true};
-            Console.SetOut(streamwriter);
-            Console.SetError(streamwriter);
+            //var filestream = new FileStream(Path.Combine(AppEnvironment.DataPath, "server.log"),
+            //    FileMode.Create);
+            //var streamwriter = new StreamWriter(filestream) {AutoFlush = true};
+         //   Console.SetOut(streamwriter);
+         //   Console.SetError(streamwriter);
             if (Settings.Empty)
             {
                 //setup listen sh

--- a/RemoteTaskServer/WebSocketAPI/Authentication/AuthClient.cs
+++ b/RemoteTaskServer/WebSocketAPI/Authentication/AuthClient.cs
@@ -17,7 +17,6 @@ namespace UlteriusServer.WebSocketAPI.Authentication
             Authenticated = false;
             AesShook = false;
         }
-        public List<int> ConnectedPorts { get; set; }
         public DateTime LastUpdate { get; set; }
         public bool Authenticated { get; set; }
         public SecureString PrivateKey { get; set; }

--- a/RemoteTaskServer/WebSocketAPI/Authentication/AuthClient.cs
+++ b/RemoteTaskServer/WebSocketAPI/Authentication/AuthClient.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
 using System.Security;
 using vtortola.WebSockets;
 
@@ -10,15 +11,13 @@ namespace UlteriusServer.WebSocketAPI.Authentication
 {
     public class AuthClient
     {
-        public AuthClient(WebSocket client)
+        public AuthClient()
         {
-            Client = client;
             LastUpdate = DateTime.Now;
             Authenticated = false;
             AesShook = false;
         }
-
-        public WebSocket Client { get; set; }
+        public List<int> ConnectedPorts { get; set; }
         public DateTime LastUpdate { get; set; }
         public bool Authenticated { get; set; }
         public SecureString PrivateKey { get; set; }

--- a/RemoteTaskServer/WebSocketAPI/Authentication/CookieManager.cs
+++ b/RemoteTaskServer/WebSocketAPI/Authentication/CookieManager.cs
@@ -1,0 +1,22 @@
+﻿#region
+
+using System;
+using vtortola.WebSockets;
+
+#endregion
+
+namespace UlteriusServer.WebSocketAPI.Authentication
+{
+    public static class CookieManager
+    {
+        public static Guid GetConnectionId(WebSocket clientSocket)
+        {
+            Guid connectionId;
+            var cookie = clientSocket.HttpRequest.Cookies["ConnectionId"] ??
+                         clientSocket.HttpResponse.Cookies["ConnectionId"];
+            if (cookie == null || !Guid.TryParse(cookie.Value, out connectionId))
+                return Guid.Empty;
+            return connectionId;
+        }
+    }
+}

--- a/RemoteTaskServer/packages.config
+++ b/RemoteTaskServer/packages.config
@@ -18,5 +18,5 @@
   <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net461" />
   <package id="Open.NAT" version="2.1.0.0" targetFramework="net461" />
   <package id="OpenHardwareMonitor" version="0.7.1" targetFramework="net461" />
-  <package id="vtortola.WebSocketListener" version="2.2.0.3" targetFramework="net461" />
+  <package id="vtortola.WebSocketListener" version="2.2.1.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Rewrote how sockets are handled so we can have multiple sockets under the same API handler, this means auth states can be shared without reauthing users over and over. 

File search code has been moved into the main stack as there is no point in having an external DLL. Screenshare will follow soon. 

Why the rewrite? Cron jobs are coming soon and we didn't feel there should be yet another authorization for yet another socket. Websockets are great, the one message at a time limitation is not. 
